### PR TITLE
Link to BIOS if BIOS_URL not set

### DIFF
--- a/lib/mastermind_slack/bot.ex
+++ b/lib/mastermind_slack/bot.ex
@@ -2,7 +2,12 @@ defmodule MastermindSlack.Bot do
   use Slack
 
   def start_link(initial_state) do
-    Slack.start_link(__MODULE__, System.get_env("SLACK_BOT_API_TOKEN"), initial_state)
+    token = System.get_env("SLACK_BOT_API_TOKEN")
+    if token do
+      Slack.start_link(__MODULE__, System.get_env("SLACK_BOT_API_TOKEN"), initial_state)
+    else
+      exit "SLACK_BOT_API_TOKEN was not found, did you set it?"
+    end
   end
 
   def init(initial_state, slack) do

--- a/lib/mastermind_slack/bot/handler.ex
+++ b/lib/mastermind_slack/bot/handler.ex
@@ -1,6 +1,7 @@
 defmodule MastermindSlack.Bot.Handler do
+  @bios_url System.get_env("BIOS_URL") || 'http://j.mp/biosbiosbios'
   @bios """
-  Oh you mean these? #{System.get_env("BIOS_URL")}
+  Oh you mean these? #{@bios_url}
   """
 
   def handle("show me those bios though", channel, slack=%Slack.State{}, state) do


### PR DESCRIPTION
Link to appropriate page when `BIOS_URL` environment variable is not set.

Added bonus: bail out with a descriptive error message if the `SLACK_BOT_API_TOKEN` hasn't been set.
